### PR TITLE
정맥으로 보내던 피를 동맥으로 보내도록 수정

### DIFF
--- a/classes/GatewaySocket.js
+++ b/classes/GatewaySocket.js
@@ -94,7 +94,7 @@ class GatewaySocket extends WebSocket {
    * @returns {void}
    */
   sendHeartbeat () {
-    this.send(JSON.stringify({ op: 11 }))
+    this.send(JSON.stringify({ op: 1 }))
   }
 }
 


### PR DESCRIPTION
피가 동맥으로 가서 정맥으로 가야 하지만 정맥으로 보내고 있어 디스코드 서버가 심장이 뛰는지 알 수 없었습니다.